### PR TITLE
Handle Inventory Requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def handle_scene(choice, current_scene, previous_scene, inventory, total_points)
         current_scene = story[0]
     else:
         choice_index = choice - 1
-        options = get_story_links(current_scene)
+        options = get_story_links(current_scene, inventory)
         option_id = options[choice_index]["id"]
         if option_id == "EXIT":
             print("\n\nTHANKS FOR PLAYING!\n\n")

--- a/scenes/nodes.py
+++ b/scenes/nodes.py
@@ -7,7 +7,7 @@
 #         "point_adjust": 100,
 #         "new_inventory": "Friend Maria",
 #         "links": [
-#             {"label":"Option B", "id":"B"},
+#             {"label":"Option B", "id":"B", "requirements":"Maria"},
 #             {"label":"Option C", "id":"C"}
 #         ]
 #     },{
@@ -61,7 +61,7 @@ def get_story_new_inventory(scene):
         return None
 
 # Get links from scene
-def get_story_links(scene):
+def get_story_links(scene, user_inventory=[]):
     if "links" in scene:
         return scene["links"]
     else:

--- a/scenes/nodes.py
+++ b/scenes/nodes.py
@@ -62,7 +62,26 @@ def get_story_new_inventory(scene):
 
 # Get links from scene
 def get_story_links(scene, user_inventory=[]):
+    limited_scenes = []
     if "links" in scene:
-        return scene["links"]
+        
+        # Check for requirements in any links
+        for link in scene["links"]:
+
+            # If there's a requirement for the scene, 
+            # check if user meets the requirement
+            if "requirements" in link:
+
+                # Iterate through requirements
+                for requirement in link["requirements"]:
+                    if requirement in user_inventory:
+                        limited_scenes.append(link)
+            
+            # If there's no requirement, give it as an option.
+            else:
+                limited_scenes.append(link)
+
+        # Return limited scenes that match requirements
+        return limited_scenes
     else:
         return None

--- a/scenes/nodes.py
+++ b/scenes/nodes.py
@@ -76,6 +76,7 @@ def get_story_links(scene, user_inventory=[]):
                 for requirement in link["requirements"]:
                     if requirement in user_inventory:
                         limited_scenes.append(link)
+                        break
             
             # If there's no requirement, give it as an option.
             else:

--- a/scenes/nodes.py
+++ b/scenes/nodes.py
@@ -85,4 +85,9 @@ def get_story_links(scene, user_inventory=[]):
         # Return limited scenes that match requirements
         return limited_scenes
     else:
-        return None
+        return [
+            {
+                "label": "Back to Start Menu",
+                "id": "START"
+            }
+        ]

--- a/stories/developer_adventure_level_10.py
+++ b/stories/developer_adventure_level_10.py
@@ -10,26 +10,40 @@ level_10 = [
                 "[[resetColor]]",
         "links": [
             {
-                "label": "Study, of course",
-                "id": "Level10_SceneA"
+                "label": "What's next?",
+                "id": "Level11_SceneA",
+                "requirements": ["Friend Johny"]
             }, {
-                "label": "Party like never before",
-                "id": "Level10_SceneB"
+                "label": "What's next?",
+                "id": "Level11_SceneB"
+                # Either BOTH friends or NEITHER friend...
+                # "requirements": ["Friend Johny","Friend Kevin"]
+            }, {
+                "label": "What's next?",
+                "id": "Level11_SceneC",
+                "requirements": ["Friend Kevin"]
             }
         ]
     }, {
         "id": "Level10_SceneB",
         "text": "[[cyan]]"
-                "YIt's always Friday at your place. What an impressive four years of school. You could definitely \n"
+                "It's always Friday at your place. What an impressive four years of school. You could definitely \n"
                 "use what you have learned about CS in your bright future."
                 "[[resetColor]]",
         "links": [
             {
-                "label": "Make friends and chill",
-                "id": "Level10_SceneB"
+                "label": "What's next?",
+                "id": "Level11_SceneB",
+                "requirements": ["Friend Johny"]
             }, {
                 "label": "Earn money, money, money",
-                "id": "Level10_SceneC"
+                "id": "Level11_SceneC"
+                # Either BOTH friends or NEITHER friend...
+                # "requirements": ["Friend Johny","Friend Kevin"]
+            }, {
+                "label": "What's next?",
+                "id": "Level11_SceneE",
+                "requirements": ["Friend Kevin"]
             }
         ]
     }, {
@@ -41,11 +55,18 @@ level_10 = [
                 "[[resetColor]]",
         "links": [
             {
-                "label": "Forget about my studies",
-                "id": "Level10_SceneB"
+                "label": "What's next?",
+                "id": "Level11_SceneD",
+                "requirements": ["Friend Johny"]
             }, {
-                "label": "Start working and getting on my feet",
-                "id": "Level10_SceneC"
+                "label": "What's next?",
+                "id": "Level11_SceneF",
+                "requirements": ["Friend Kevin"]
+            }, {
+                "label": "What's next?",
+                "id": "Level11_SceneE"
+                # Either BOTH friends or NEITHER friend...
+                # "requirements": ["Friend Johny","Friend Kevin"]
             }
         ]
     }

--- a/stories/developer_adventure_level_3.py
+++ b/stories/developer_adventure_level_3.py
@@ -6,6 +6,7 @@ level_3 = [
                 "tech-savvy and based on his profile information he has won multiple STEM awards in his school. \n"
                 "You sent a friend request. He accepted it and you started to chat with Johny. Remember: you have a \n"
                 "test tomorrow. What are you going to do?[[resetColor]]",
+        "new_inventory": "Friend Johny",
         "links": [
             {
                 "label": "Say you have a test tomorrow and probably will catch up later",

--- a/stories/developer_adventure_level_4.py
+++ b/stories/developer_adventure_level_4.py
@@ -6,6 +6,7 @@ level_4 = [
                 "Jeremy. He is a very cool dude, even though he stayed in the same grade twice. It's almost 4 am, \n"
                 "people are starting to leave. What's your plan?"
                 "[[resetColor]]",
+        "new_inventory": "Friend Jeremy",
         "links": [
             {
                 "label": "Go home, it's getting too late",

--- a/stories/developer_adventure_level_9.py
+++ b/stories/developer_adventure_level_9.py
@@ -8,6 +8,7 @@ level_9 = [
                 "about IT security and its importance. Interesting topic. Finish the sentence: during my last year \n"
                 "of college I want to ..."
                 "[[resetColor]]",
+        "new_inventory": "IT Helpdesk Job Experience",
         "links": [
             {
                 "label": "Study, of course",
@@ -25,6 +26,7 @@ level_9 = [
                 "not) to get money using your knowledge of computer science. You hear things like \"dark web\". \n"
                 "Finish the sentence: next year I want to ..."
                 "[[resetColor]]",
+        "new_inventory": "Pizza Job Experience",
         "links": [
             {
                 "label": "Make friends and chill",
@@ -43,6 +45,7 @@ level_9 = [
                 "place where you are learning good and bad things you can do in IT. Finish the sentence: during \n"
                 "my last year of college I want to ..."
                 "[[resetColor]]",
+        "new_inventory": "RadioShack Job Experience",
         "links": [
             {
                 "label": "Forget about my studies",
@@ -60,6 +63,7 @@ level_9 = [
                 "experience. You get to create new applications and think about security. Finish the sentence: \n"
                 "during my last year of college I want to ..."
                 "[[resetColor]]",
+        "new_inventory": "Research Assistant Job Experience",
         "links": [
             {
                 "label": "Finish the school like a champ",

--- a/tests/test_scene_nodes.py
+++ b/tests/test_scene_nodes.py
@@ -1,6 +1,13 @@
 from scenes.nodes import get_story_text, get_scene_from_story, get_story_point_adjustments, get_story_new_inventory, get_story_links, get_story_file
 import pytest
 
+start_link = [
+            {
+                "label": "Back to Start Menu",
+                "id": "START"
+            }
+        ]
+
 sample_scene_node = {
     "id": "single_node",
     "text": "hello world",
@@ -99,7 +106,7 @@ def test_get_story_new_inventory(scene, result):
     (sample_scene_array[1], [
         {"label":"Option C", "id":"C"}
     ]),
-    (sample_scene_array[2], None)
+    (sample_scene_array[2], start_link)
 ])
 def test_get_story_links(scene, result):
     assert get_story_links(scene) == result

--- a/tests/test_scene_nodes_requirements.py
+++ b/tests/test_scene_nodes_requirements.py
@@ -38,10 +38,10 @@ sample_scene_node = {
         ["Friend John"],
         [link1, link3, link4]
     ),(
-    #     sample_scene_node, 
-    #     ["Friend John","sword"],
-    #     [link1, link2, link3, link4]
-    # ),(
+        sample_scene_node, 
+        ["Friend John","sword"],
+        [link1, link2, link3, link4]
+    ),(
         sample_scene_node, 
         ["sword"],
         [link1, link2, link4]

--- a/tests/test_scene_nodes_requirements.py
+++ b/tests/test_scene_nodes_requirements.py
@@ -9,13 +9,19 @@ link1 = {
 link2 = {
             "label":"Choice 2", 
             "id":"2",
-            "requirements":"sword"
+            "requirements":["sword"]
         }
 
 link3 = {
             "label":"Choice 3",
             "id":"3",
-            "requirements":"John"
+            "requirements":["Friend John"]
+        }
+
+link4 = {
+            "label":"Choice 4", 
+            "id":"4",
+            "requirements":["sword","Friend John"]
         }
 
 sample_scene_node = {
@@ -23,21 +29,23 @@ sample_scene_node = {
     "text": "hello world",
     "point_adjust": 100,
     "new_inventory": "Friend Maria",
-    "links": [link1,link2,link3]
+    "links": [link1,link2,link3,link4]
 }
-
-user_inventory = ["Friend John"]
 
 @pytest.mark.parametrize('scene, user_inventory, result', [
     (
+        sample_scene_node, 
+        ["Friend John"],
+        [link1, link3, link4]
+    ),(
     #     sample_scene_node, 
-    #     ["Friend John"],
-    #     [link1, link3]
+    #     ["Friend John","sword"],
+    #     [link1, link2, link3, link4]
     # ),(
         sample_scene_node, 
-        ["Friend John","Great Sword"],
-        [link1, link2, link3]
+        ["sword"],
+        [link1, link2, link4]
     )
 ])
-def test_get_story_links(scene, user_inventory, result):
-    assert get_story_links(scene) == result
+def test_get_story_links_with_exact_requirements(scene, user_inventory, result):
+    assert get_story_links(scene, user_inventory) == result

--- a/tests/test_scene_nodes_requirements.py
+++ b/tests/test_scene_nodes_requirements.py
@@ -45,6 +45,14 @@ sample_scene_node = {
         sample_scene_node, 
         ["sword"],
         [link1, link2, link4]
+    ),(
+        sample_scene_node, 
+        ["Friend Maria"],
+        [link1]
+    ),(
+        sample_scene_node, 
+        [],
+        [link1]
     )
 ])
 def test_get_story_links_with_exact_requirements(scene, user_inventory, result):

--- a/tests/test_scene_nodes_requirements.py
+++ b/tests/test_scene_nodes_requirements.py
@@ -1,0 +1,43 @@
+from scenes.nodes import get_story_links
+import pytest
+
+link1 = {
+            "label":"Choice 1", 
+            "id":"1"
+        }
+
+link2 = {
+            "label":"Choice 2", 
+            "id":"2",
+            "requirements":"sword"
+        }
+
+link3 = {
+            "label":"Choice 3",
+            "id":"3",
+            "requirements":"John"
+        }
+
+sample_scene_node = {
+    "id": "single_node",
+    "text": "hello world",
+    "point_adjust": 100,
+    "new_inventory": "Friend Maria",
+    "links": [link1,link2,link3]
+}
+
+user_inventory = ["Friend John"]
+
+@pytest.mark.parametrize('scene, user_inventory, result', [
+    (
+    #     sample_scene_node, 
+    #     ["Friend John"],
+    #     [link1, link3]
+    # ),(
+        sample_scene_node, 
+        ["Friend John","Great Sword"],
+        [link1, link2, link3]
+    )
+])
+def test_get_story_links(scene, user_inventory, result):
+    assert get_story_links(scene) == result


### PR DESCRIPTION
Check player inventory against the requirements for scene options.

The code currently requires an **EXACT** match. If the requirement is `'Friend Maria'`, the user must have an inventory item of `'Friend Maria'`; the item `'Maria'` would not match.

# New Addition for Links

Example of a link without any required inventory:

```json
{
    "label":"Choice 1", 
    "id":"1"
}
```

Example of a link that has a requirement. The user must have this item in their inventory in order to see this option:

```json
{
    "label":"Choice 2", 
    "id":"2",
    "requirements":["sword"]
}
```